### PR TITLE
[codex] Start v2 skeleton rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+coverage/
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Agent Instructions
+
+## Development Style
+
+- Work test-first when changing behavior.
+- Keep runtime `dependencies` limited to `hono` unless the architecture is explicitly revised.
+- Use handwritten CSS in `src/styles.css`; do not introduce Tailwind CSS.
+
+## Architecture Rules
+
+- Treat GitHub Issues as an external CMS adapter.
+- Normalize CMS data into the `Post` domain model before it reaches routes or presentation components.
+- Keep presentation components dependent only on domain types and shared helpers.
+- Keep GitHub-specific code under `src/cms/github-issues` in later phases.
+
+## Forbidden Changes
+
+- Do not introduce Next.js.
+- Do not introduce a database.
+- Do not pass raw GitHub Issue objects into routes or presentation components.
+- Do not bypass Markdown sanitization when the Markdown pipeline is added.
+- Do not leave placeholder URLs.
+
+## Checks
+
+Run these before finishing implementation work:
+
+```sh
+npm test
+npm run typecheck
+npm run lint
+npm run build
+```

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2040 @@
+{
+  "name": "minimal-blog",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "minimal-blog",
+      "version": "0.1.0",
+      "dependencies": {
+        "hono": "^4.10.7"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.3.8",
+        "@types/node": "^24.10.1",
+        "tsx": "^4.20.6",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.14"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.13.tgz",
+      "integrity": "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.13",
+        "@biomejs/cli-darwin-x64": "2.4.13",
+        "@biomejs/cli-linux-arm64": "2.4.13",
+        "@biomejs/cli-linux-arm64-musl": "2.4.13",
+        "@biomejs/cli-linux-x64": "2.4.13",
+        "@biomejs/cli-linux-x64-musl": "2.4.13",
+        "@biomejs/cli-win32-arm64": "2.4.13",
+        "@biomejs/cli-win32-x64": "2.4.13"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.13.tgz",
+      "integrity": "sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.13.tgz",
+      "integrity": "sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.13.tgz",
+      "integrity": "sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.13.tgz",
+      "integrity": "sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.13.tgz",
+      "integrity": "sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.13.tgz",
+      "integrity": "sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.13.tgz",
+      "integrity": "sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.13.tgz",
+      "integrity": "sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "minimal-blog",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsx src/build/build.ts",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "format": "biome format --write .",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "hono": "^4.10.7"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.3.8",
+    "@types/node": "^24.10.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.14"
+  }
+}

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,0 +1,26 @@
+import { Hono } from "hono";
+import type { SiteConfig } from "../config/site.config";
+import type { ContentIndex } from "../content/usecases/buildContentIndex";
+import { registerArchiveRoute } from "./routes/archive.route";
+import { registerHomeRoute } from "./routes/home.route";
+import { renderNotFound } from "./routes/notFound.route";
+import { registerPostRoutes } from "./routes/post.route";
+import { registerTagRoute } from "./routes/tag.route";
+
+type CreateAppOptions = {
+  contentIndex: ContentIndex;
+  siteConfig: SiteConfig;
+};
+
+export const createApp = (options: CreateAppOptions): Hono => {
+  const app = new Hono();
+
+  registerHomeRoute(app, options);
+  registerPostRoutes(app, options);
+  registerTagRoute(app, options);
+  registerArchiveRoute(app, options);
+
+  app.notFound((c) => renderNotFound(c, options.siteConfig));
+
+  return app;
+};

--- a/src/app/routes/archive.route.tsx
+++ b/src/app/routes/archive.route.tsx
@@ -1,0 +1,27 @@
+import type { Hono } from "hono";
+import type { SiteConfig } from "../../config/site.config";
+import type { ContentIndex } from "../../content/usecases/buildContentIndex";
+import { listArchiveMonths } from "../../content/usecases/listArchiveMonths";
+import { Layout } from "../../presentation/components/Layout";
+import { ArchivePage } from "../../presentation/pages/ArchivePage";
+
+type RouteOptions = {
+  contentIndex: ContentIndex;
+  siteConfig: SiteConfig;
+};
+
+export const registerArchiveRoute = (
+  app: Hono,
+  options: RouteOptions,
+): void => {
+  app.get("/archive/", (c) =>
+    c.html(
+      <Layout siteConfig={options.siteConfig} title="Archive">
+        <ArchivePage
+          archiveMonths={listArchiveMonths(options.contentIndex)}
+          siteConfig={options.siteConfig}
+        />
+      </Layout>,
+    ),
+  );
+};

--- a/src/app/routes/home.route.tsx
+++ b/src/app/routes/home.route.tsx
@@ -1,0 +1,24 @@
+import type { Hono } from "hono";
+import type { SiteConfig } from "../../config/site.config";
+import type { ContentIndex } from "../../content/usecases/buildContentIndex";
+import { listPublishedPosts } from "../../content/usecases/listPublishedPosts";
+import { Layout } from "../../presentation/components/Layout";
+import { HomePage } from "../../presentation/pages/HomePage";
+
+type RouteOptions = {
+  contentIndex: ContentIndex;
+  siteConfig: SiteConfig;
+};
+
+export const registerHomeRoute = (app: Hono, options: RouteOptions): void => {
+  app.get("/", (c) =>
+    c.html(
+      <Layout siteConfig={options.siteConfig}>
+        <HomePage
+          posts={listPublishedPosts(options.contentIndex)}
+          siteConfig={options.siteConfig}
+        />
+      </Layout>,
+    ),
+  );
+};

--- a/src/app/routes/notFound.route.tsx
+++ b/src/app/routes/notFound.route.tsx
@@ -1,0 +1,12 @@
+import type { Context } from "hono";
+import type { SiteConfig } from "../../config/site.config";
+import { Layout } from "../../presentation/components/Layout";
+import { NotFoundPage } from "../../presentation/pages/NotFoundPage";
+
+export const renderNotFound = (c: Context, siteConfig: SiteConfig) =>
+  c.html(
+    <Layout siteConfig={siteConfig} title="Not Found">
+      <NotFoundPage siteConfig={siteConfig} />
+    </Layout>,
+    404,
+  );

--- a/src/app/routes/post.route.tsx
+++ b/src/app/routes/post.route.tsx
@@ -1,0 +1,59 @@
+import type { Hono } from "hono";
+import { ssgParams } from "hono/ssg";
+import type { SiteConfig } from "../../config/site.config";
+import type { ContentIndex } from "../../content/usecases/buildContentIndex";
+import { getPostBySlug } from "../../content/usecases/getPostBySlug";
+import { listPublishedPosts } from "../../content/usecases/listPublishedPosts";
+import { Layout } from "../../presentation/components/Layout";
+import { HomePage } from "../../presentation/pages/HomePage";
+import { NotFoundPage } from "../../presentation/pages/NotFoundPage";
+import { PostPage } from "../../presentation/pages/PostPage";
+
+type RouteOptions = {
+  contentIndex: ContentIndex;
+  siteConfig: SiteConfig;
+};
+
+export const registerPostRoutes = (app: Hono, options: RouteOptions): void => {
+  app.get("/posts/", (c) =>
+    c.html(
+      <Layout siteConfig={options.siteConfig} title="Posts">
+        <HomePage
+          posts={listPublishedPosts(options.contentIndex)}
+          siteConfig={options.siteConfig}
+        />
+      </Layout>,
+    ),
+  );
+
+  app.get(
+    "/posts/:slug/",
+    ssgParams(
+      options.contentIndex.detailPosts.map((post) => ({
+        slug: post.slug,
+      })),
+    ),
+    (c) => {
+      const post = getPostBySlug(options.contentIndex, c.req.param("slug"));
+
+      if (!post) {
+        return c.html(
+          <Layout siteConfig={options.siteConfig} title="Not Found">
+            <NotFoundPage siteConfig={options.siteConfig} />
+          </Layout>,
+          404,
+        );
+      }
+
+      return c.html(
+        <Layout
+          description={post.description}
+          siteConfig={options.siteConfig}
+          title={post.title}
+        >
+          <PostPage post={post} siteConfig={options.siteConfig} />
+        </Layout>,
+      );
+    },
+  );
+};

--- a/src/app/routes/tag.route.tsx
+++ b/src/app/routes/tag.route.tsx
@@ -1,0 +1,40 @@
+import type { Hono } from "hono";
+import { ssgParams } from "hono/ssg";
+import type { SiteConfig } from "../../config/site.config";
+import type { ContentIndex } from "../../content/usecases/buildContentIndex";
+import { listTags } from "../../content/usecases/listTags";
+import { Layout } from "../../presentation/components/Layout";
+import { NotFoundPage } from "../../presentation/pages/NotFoundPage";
+import { TagPage } from "../../presentation/pages/TagPage";
+
+type RouteOptions = {
+  contentIndex: ContentIndex;
+  siteConfig: SiteConfig;
+};
+
+export const registerTagRoute = (app: Hono, options: RouteOptions): void => {
+  const tags = listTags(options.contentIndex);
+
+  app.get(
+    "/tags/:tag/",
+    ssgParams(tags.map((tag) => ({ tag: tag.slug }))),
+    (c) => {
+      const tag = tags.find((tagGroup) => tagGroup.slug === c.req.param("tag"));
+
+      if (!tag) {
+        return c.html(
+          <Layout siteConfig={options.siteConfig} title="Not Found">
+            <NotFoundPage siteConfig={options.siteConfig} />
+          </Layout>,
+          404,
+        );
+      }
+
+      return c.html(
+        <Layout siteConfig={options.siteConfig} title={`Tag: ${tag.name}`}>
+          <TagPage siteConfig={options.siteConfig} tag={tag} />
+        </Layout>,
+      );
+    },
+  );
+};

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -1,0 +1,32 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { cleanDist } from "./cleanDist";
+import { copyPublicAssets } from "./copyPublicAssets";
+import { createBuildContext } from "./createBuildContext";
+import { generateStaticSite } from "./generateStaticSite";
+import { validateOutput } from "./validateOutput";
+
+export const buildSite = async (): Promise<void> => {
+  const distDir = path.resolve("dist");
+  const context = await createBuildContext();
+
+  await cleanDist(distDir);
+  await generateStaticSite(context.app, distDir);
+  await copyPublicAssets(distDir);
+  await validateOutput(distDir, context.contentIndex);
+};
+
+const isMainModule = (): boolean => {
+  if (!process.argv[1]) {
+    return false;
+  }
+
+  return fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+};
+
+if (isMainModule()) {
+  buildSite().catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/src/build/cleanDist.ts
+++ b/src/build/cleanDist.ts
@@ -1,0 +1,5 @@
+import { rm } from "node:fs/promises";
+
+export const cleanDist = async (distDir: string): Promise<void> => {
+  await rm(distDir, { force: true, recursive: true });
+};

--- a/src/build/copyPublicAssets.ts
+++ b/src/build/copyPublicAssets.ts
@@ -1,0 +1,31 @@
+import { access, cp, mkdir, stat } from "node:fs/promises";
+import path from "node:path";
+
+const exists = async (targetPath: string): Promise<boolean> => {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const copyPublicAssets = async (distDir: string): Promise<void> => {
+  const staticDir = path.join(distDir, "static");
+  await mkdir(staticDir, { recursive: true });
+  await cp("src/styles.css", path.join(staticDir, "styles.css"));
+
+  if (!(await exists("public"))) {
+    return;
+  }
+
+  const publicStats = await stat("public");
+  if (!publicStats.isDirectory()) {
+    return;
+  }
+
+  await cp("public", distDir, {
+    force: true,
+    recursive: true,
+  });
+};

--- a/src/build/createBuildContext.ts
+++ b/src/build/createBuildContext.ts
@@ -1,0 +1,17 @@
+import { createApp } from "../app/app";
+import { siteConfig } from "../config/site.config";
+import { FixtureContentRepository } from "../content/fixtures/FixtureContentRepository";
+import { buildContentIndex } from "../content/usecases/buildContentIndex";
+
+export const createBuildContext = async () => {
+  const repository = new FixtureContentRepository();
+  const posts = await repository.listPosts();
+  const contentIndex = buildContentIndex(posts);
+  const app = createApp({ contentIndex, siteConfig });
+
+  return {
+    app,
+    contentIndex,
+    siteConfig,
+  };
+};

--- a/src/build/generateStaticSite.ts
+++ b/src/build/generateStaticSite.ts
@@ -1,0 +1,16 @@
+import * as fs from "node:fs/promises";
+import type { Hono } from "hono";
+import { toSSG } from "hono/ssg";
+
+export const generateStaticSite = async (
+  app: Hono,
+  distDir: string,
+): Promise<void> => {
+  const result = await toSSG(app, fs, {
+    dir: distDir,
+  });
+
+  if (!result.success) {
+    throw result.error ?? new Error("Static site generation failed");
+  }
+};

--- a/src/build/validateOutput.ts
+++ b/src/build/validateOutput.ts
@@ -1,0 +1,30 @@
+import { access } from "node:fs/promises";
+import path from "node:path";
+import type { ContentIndex } from "../content/usecases/buildContentIndex";
+
+export const validateOutput = async (
+  distDir: string,
+  contentIndex: ContentIndex,
+): Promise<void> => {
+  const requiredFiles = [
+    "index.html",
+    path.join("posts", "index.html"),
+    path.join("archive", "index.html"),
+    path.join("static", "styles.css"),
+    ...contentIndex.detailPosts.map((post) =>
+      path.join("posts", post.slug, "index.html"),
+    ),
+  ];
+
+  for (const requiredFile of requiredFiles) {
+    await assertFileExists(path.join(distDir, requiredFile));
+  }
+};
+
+const assertFileExists = async (filePath: string): Promise<void> => {
+  try {
+    await access(filePath);
+  } catch {
+    throw new Error(`Expected generated file is missing: ${filePath}`);
+  }
+};

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,7 @@
+export type AppEnv = {
+  nodeEnv: string;
+};
+
+export const loadEnv = (): AppEnv => ({
+  nodeEnv: process.env.NODE_ENV ?? "development",
+});

--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -1,0 +1,16 @@
+export type SiteConfig = {
+  title: string;
+  description: string;
+  url: string;
+  basePath: string;
+  author: string;
+};
+
+export const siteConfig: SiteConfig = {
+  title: "Minimal Blog",
+  description:
+    "A zero-runtime-dependency static blog generator backed by GitHub Issues.",
+  url: "https://6uclz1.github.io/minimal-blog",
+  basePath: "/minimal-blog",
+  author: "6uclz1",
+};

--- a/src/content/domain/Post.ts
+++ b/src/content/domain/Post.ts
@@ -1,0 +1,28 @@
+import type { PostStatus } from "./PostStatus";
+
+export type Post = {
+  id: string;
+  source: {
+    type: "github-issue";
+    issueNumber: number;
+    issueUrl: string;
+  };
+  slug: string;
+  title: string;
+  description: string;
+  excerpt: string;
+  bodyMarkdown: string;
+  bodyHtml: string;
+  labels: string[];
+  tags: string[];
+  status: PostStatus;
+  pinned: boolean;
+  hidden: boolean;
+  noindex: boolean;
+  canonicalUrl?: string;
+  ogImage?: string;
+  publishedAt: Date;
+  updatedAt: Date;
+  author: string;
+  readingTimeMinutes: number;
+};

--- a/src/content/domain/PostStatus.ts
+++ b/src/content/domain/PostStatus.ts
@@ -1,0 +1,1 @@
+export type PostStatus = "published" | "draft" | "archived";

--- a/src/content/fixtures/FixtureContentRepository.ts
+++ b/src/content/fixtures/FixtureContentRepository.ts
@@ -1,0 +1,8 @@
+import type { ContentRepository } from "../ports/ContentRepository";
+import { fixturePosts } from "./fixturePosts";
+
+export class FixtureContentRepository implements ContentRepository {
+  async listPosts() {
+    return fixturePosts;
+  }
+}

--- a/src/content/fixtures/fixturePosts.ts
+++ b/src/content/fixtures/fixturePosts.ts
@@ -1,0 +1,82 @@
+import type { Post } from "../domain/Post";
+
+export const fixturePosts: Post[] = [
+  {
+    id: "github-issue-1",
+    source: {
+      type: "github-issue",
+      issueNumber: 1,
+      issueUrl: "https://github.com/6uclz1/minimal-blog/issues/1",
+    },
+    slug: "hello-hono",
+    title: "Hello Hono",
+    description: "A first fixture post for the v2 static generator.",
+    excerpt: "A first fixture post for the v2 static generator.",
+    bodyMarkdown:
+      "This fixture already contains rendered HTML for the Phase 1 skeleton.",
+    bodyHtml:
+      "<p>This fixture already contains rendered HTML for the Phase 1 skeleton.</p>",
+    labels: ["post", "published", "tag:hono"],
+    tags: ["hono"],
+    status: "published",
+    pinned: true,
+    hidden: false,
+    noindex: false,
+    publishedAt: new Date("2026-04-30T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-30T00:00:00.000Z"),
+    author: "6uclz1",
+    readingTimeMinutes: 1,
+  },
+  {
+    id: "github-issue-2",
+    source: {
+      type: "github-issue",
+      issueNumber: 2,
+      issueUrl: "https://github.com/6uclz1/minimal-blog/issues/2",
+    },
+    slug: "content-model-first",
+    title: "Content Model First",
+    description: "A fixture post about keeping CMS data out of presentation.",
+    excerpt: "A fixture post about keeping CMS data out of presentation.",
+    bodyMarkdown:
+      "Routes and components receive normalized Post objects, not GitHub Issue payloads.",
+    bodyHtml:
+      "<p>Routes and components receive normalized Post objects, not GitHub Issue payloads.</p>",
+    labels: ["post", "published", "tag:architecture"],
+    tags: ["architecture"],
+    status: "published",
+    pinned: false,
+    hidden: false,
+    noindex: false,
+    publishedAt: new Date("2026-04-29T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-29T00:00:00.000Z"),
+    author: "6uclz1",
+    readingTimeMinutes: 1,
+  },
+  {
+    id: "github-issue-3",
+    source: {
+      type: "github-issue",
+      issueNumber: 3,
+      issueUrl: "https://github.com/6uclz1/minimal-blog/issues/3",
+    },
+    slug: "hidden-implementation-note",
+    title: "Hidden Implementation Note",
+    description: "A hidden fixture post that still gets a detail page.",
+    excerpt: "A hidden fixture post that still gets a detail page.",
+    bodyMarkdown:
+      "Hidden posts are excluded from list pages but remain addressable by slug.",
+    bodyHtml:
+      "<p>Hidden posts are excluded from list pages but remain addressable by slug.</p>",
+    labels: ["post", "published", "hidden", "tag:architecture"],
+    tags: ["architecture"],
+    status: "published",
+    pinned: false,
+    hidden: true,
+    noindex: false,
+    publishedAt: new Date("2026-04-28T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-28T00:00:00.000Z"),
+    author: "6uclz1",
+    readingTimeMinutes: 1,
+  },
+];

--- a/src/content/ports/ContentRepository.ts
+++ b/src/content/ports/ContentRepository.ts
@@ -1,0 +1,5 @@
+import type { Post } from "../domain/Post";
+
+export interface ContentRepository {
+  listPosts(): Promise<Post[]>;
+}

--- a/src/content/usecases/buildContentIndex.ts
+++ b/src/content/usecases/buildContentIndex.ts
@@ -1,0 +1,117 @@
+import type { Post } from "../domain/Post";
+
+export type TagGroup = {
+  name: string;
+  slug: string;
+  posts: Post[];
+};
+
+export type ArchiveMonth = {
+  month: string;
+  label: string;
+  posts: Post[];
+};
+
+export type ContentIndex = {
+  allPosts: Post[];
+  detailPosts: Post[];
+  publishedPosts: Post[];
+  postsBySlug: Map<string, Post>;
+  tags: TagGroup[];
+  archiveMonths: ArchiveMonth[];
+};
+
+export const buildContentIndex = (posts: Post[]): ContentIndex => {
+  assertUniqueSlugs(posts);
+
+  const allPosts = sortPosts(posts);
+  const detailPosts = allPosts.filter((post) => post.status === "published");
+  const visiblePublishedPosts = detailPosts.filter((post) => !post.hidden);
+
+  return {
+    allPosts,
+    detailPosts,
+    publishedPosts: visiblePublishedPosts,
+    postsBySlug: new Map(detailPosts.map((post) => [post.slug, post])),
+    tags: buildTagGroups(visiblePublishedPosts),
+    archiveMonths: buildArchiveMonths(visiblePublishedPosts),
+  };
+};
+
+const assertUniqueSlugs = (posts: Post[]): void => {
+  const seen = new Set<string>();
+
+  for (const post of posts) {
+    if (seen.has(post.slug)) {
+      throw new Error(`Duplicate post slug: "${post.slug}"`);
+    }
+    seen.add(post.slug);
+  }
+};
+
+const sortPosts = (posts: Post[]): Post[] =>
+  [...posts].sort((a, b) => {
+    if (a.pinned !== b.pinned) {
+      return a.pinned ? -1 : 1;
+    }
+
+    const publishedDiff = b.publishedAt.getTime() - a.publishedAt.getTime();
+    if (publishedDiff !== 0) {
+      return publishedDiff;
+    }
+
+    return a.slug.localeCompare(b.slug);
+  });
+
+const buildTagGroups = (posts: Post[]): TagGroup[] => {
+  const groups = new Map<string, Post[]>();
+
+  for (const post of posts) {
+    for (const tag of post.tags) {
+      const normalizedTag = tag.trim();
+      if (!normalizedTag) {
+        continue;
+      }
+
+      groups.set(normalizedTag, [...(groups.get(normalizedTag) ?? []), post]);
+    }
+  }
+
+  return [...groups.entries()]
+    .map(([name, taggedPosts]) => ({
+      name,
+      slug: name,
+      posts: taggedPosts,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+};
+
+const buildArchiveMonths = (posts: Post[]): ArchiveMonth[] => {
+  const groups = new Map<string, Post[]>();
+
+  for (const post of posts) {
+    const month = toArchiveMonth(post.publishedAt);
+    groups.set(month, [...(groups.get(month) ?? []), post]);
+  }
+
+  return [...groups.entries()]
+    .map(([month, archivedPosts]) => ({
+      month,
+      label: formatArchiveMonthLabel(month),
+      posts: archivedPosts,
+    }))
+    .sort((a, b) => b.month.localeCompare(a.month));
+};
+
+const toArchiveMonth = (date: Date): string => date.toISOString().slice(0, 7);
+
+const formatArchiveMonthLabel = (month: string): string => {
+  const [year, monthNumber] = month.split("-");
+  const date = new Date(`${year}-${monthNumber}-01T00:00:00.000Z`);
+
+  return new Intl.DateTimeFormat("en", {
+    month: "long",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(date);
+};

--- a/src/content/usecases/getPostBySlug.ts
+++ b/src/content/usecases/getPostBySlug.ts
@@ -1,0 +1,7 @@
+import type { Post } from "../domain/Post";
+import type { ContentIndex } from "./buildContentIndex";
+
+export const getPostBySlug = (
+  index: ContentIndex,
+  slug: string,
+): Post | undefined => index.postsBySlug.get(slug);

--- a/src/content/usecases/listArchiveMonths.ts
+++ b/src/content/usecases/listArchiveMonths.ts
@@ -1,0 +1,4 @@
+import type { ArchiveMonth, ContentIndex } from "./buildContentIndex";
+
+export const listArchiveMonths = (index: ContentIndex): ArchiveMonth[] =>
+  index.archiveMonths;

--- a/src/content/usecases/listPublishedPosts.ts
+++ b/src/content/usecases/listPublishedPosts.ts
@@ -1,0 +1,5 @@
+import type { Post } from "../domain/Post";
+import type { ContentIndex } from "./buildContentIndex";
+
+export const listPublishedPosts = (index: ContentIndex): Post[] =>
+  index.publishedPosts;

--- a/src/content/usecases/listTags.ts
+++ b/src/content/usecases/listTags.ts
@@ -1,0 +1,3 @@
+import type { ContentIndex, TagGroup } from "./buildContentIndex";
+
+export const listTags = (index: ContentIndex): TagGroup[] => index.tags;

--- a/src/presentation/components/DateTime.tsx
+++ b/src/presentation/components/DateTime.tsx
@@ -1,0 +1,10 @@
+import type { Post } from "../../content/domain/Post";
+import { formatDate, formatMachineDate } from "../../shared/date";
+
+type DateTimeProps = {
+  date: Post["publishedAt"];
+};
+
+export const DateTime = ({ date }: DateTimeProps) => (
+  <time dateTime={formatMachineDate(date)}>{formatDate(date)}</time>
+);

--- a/src/presentation/components/Footer.tsx
+++ b/src/presentation/components/Footer.tsx
@@ -1,0 +1,14 @@
+import type { SiteConfig } from "../../config/site.config";
+
+type FooterProps = {
+  siteConfig: SiteConfig;
+};
+
+export const Footer = ({ siteConfig }: FooterProps) => (
+  <footer class="site-footer">
+    <p>
+      Built as a static site by {siteConfig.author}. Content is modeled as
+      normalized posts.
+    </p>
+  </footer>
+);

--- a/src/presentation/components/Header.tsx
+++ b/src/presentation/components/Header.tsx
@@ -1,0 +1,18 @@
+import type { SiteConfig } from "../../config/site.config";
+import { withBasePath } from "../../shared/path";
+
+type HeaderProps = {
+  siteConfig: SiteConfig;
+};
+
+export const Header = ({ siteConfig }: HeaderProps) => (
+  <header class="site-header">
+    <a class="site-header__brand" href={withBasePath(siteConfig, "/")}>
+      {siteConfig.title}
+    </a>
+    <nav class="site-header__nav" aria-label="Primary navigation">
+      <a href={withBasePath(siteConfig, "/posts/")}>Posts</a>
+      <a href={withBasePath(siteConfig, "/archive/")}>Archive</a>
+    </nav>
+  </header>
+);

--- a/src/presentation/components/Layout.tsx
+++ b/src/presentation/components/Layout.tsx
@@ -1,0 +1,46 @@
+import { raw } from "hono/html";
+import type { Child } from "hono/jsx";
+import type { SiteConfig } from "../../config/site.config";
+import { withBasePath } from "../../shared/path";
+import { Footer } from "./Footer";
+import { Header } from "./Header";
+
+type LayoutProps = {
+  children: Child;
+  description?: string;
+  siteConfig: SiteConfig;
+  title?: string;
+};
+
+export const Layout = ({
+  children,
+  description,
+  siteConfig,
+  title,
+}: LayoutProps) => {
+  const pageTitle = title ? `${title} | ${siteConfig.title}` : siteConfig.title;
+  const pageDescription = description ?? siteConfig.description;
+
+  return (
+    <>
+      {raw("<!doctype html>")}
+      <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <title>{pageTitle}</title>
+          <meta name="description" content={pageDescription} />
+          <link
+            rel="stylesheet"
+            href={withBasePath(siteConfig, "/static/styles.css")}
+          />
+        </head>
+        <body>
+          <Header siteConfig={siteConfig} />
+          <main class="site-main">{children}</main>
+          <Footer siteConfig={siteConfig} />
+        </body>
+      </html>
+    </>
+  );
+};

--- a/src/presentation/components/PostBody.tsx
+++ b/src/presentation/components/PostBody.tsx
@@ -1,0 +1,10 @@
+import { raw } from "hono/html";
+import type { Post } from "../../content/domain/Post";
+
+type PostBodyProps = {
+  post: Post;
+};
+
+export const PostBody = ({ post }: PostBodyProps) => (
+  <div class="post-body">{raw(post.bodyHtml)}</div>
+);

--- a/src/presentation/components/PostCard.tsx
+++ b/src/presentation/components/PostCard.tsx
@@ -1,0 +1,32 @@
+import type { SiteConfig } from "../../config/site.config";
+import type { Post } from "../../content/domain/Post";
+import { postPath } from "../../shared/path";
+import { DateTime } from "./DateTime";
+import { TagBadge } from "./TagBadge";
+
+type PostCardProps = {
+  post: Post;
+  siteConfig: SiteConfig;
+};
+
+export const PostCard = ({ post, siteConfig }: PostCardProps) => (
+  <article class="post-card">
+    <header class="post-card__header">
+      <p class="post-card__meta">
+        <DateTime date={post.publishedAt} />
+        <span>{post.readingTimeMinutes} min read</span>
+      </p>
+      <h2 class="post-card__title">
+        <a href={postPath(siteConfig, post.slug)}>{post.title}</a>
+      </h2>
+    </header>
+    <p class="post-card__excerpt">{post.excerpt}</p>
+    {post.tags.length > 0 ? (
+      <div class="tag-list">
+        {post.tags.map((tag) => (
+          <TagBadge key={tag} siteConfig={siteConfig} tag={tag} />
+        ))}
+      </div>
+    ) : null}
+  </article>
+);

--- a/src/presentation/components/PostList.tsx
+++ b/src/presentation/components/PostList.tsx
@@ -1,0 +1,27 @@
+import type { SiteConfig } from "../../config/site.config";
+import type { Post } from "../../content/domain/Post";
+import { PostCard } from "./PostCard";
+
+type PostListProps = {
+  emptyMessage?: string;
+  posts: Post[];
+  siteConfig: SiteConfig;
+};
+
+export const PostList = ({
+  emptyMessage = "No posts yet.",
+  posts,
+  siteConfig,
+}: PostListProps) => {
+  if (posts.length === 0) {
+    return <p class="empty-state">{emptyMessage}</p>;
+  }
+
+  return (
+    <div class="post-list">
+      {posts.map((post) => (
+        <PostCard key={post.id} post={post} siteConfig={siteConfig} />
+      ))}
+    </div>
+  );
+};

--- a/src/presentation/components/TagBadge.tsx
+++ b/src/presentation/components/TagBadge.tsx
@@ -1,0 +1,13 @@
+import type { SiteConfig } from "../../config/site.config";
+import { tagPath } from "../../shared/path";
+
+type TagBadgeProps = {
+  siteConfig: SiteConfig;
+  tag: string;
+};
+
+export const TagBadge = ({ siteConfig, tag }: TagBadgeProps) => (
+  <a class="tag-badge" href={tagPath(siteConfig, tag)}>
+    {tag}
+  </a>
+);

--- a/src/presentation/pages/ArchivePage.tsx
+++ b/src/presentation/pages/ArchivePage.tsx
@@ -1,0 +1,36 @@
+import type { SiteConfig } from "../../config/site.config";
+import type { ArchiveMonth } from "../../content/usecases/buildContentIndex";
+import { postPath } from "../../shared/path";
+import { DateTime } from "../components/DateTime";
+
+type ArchivePageProps = {
+  archiveMonths: ArchiveMonth[];
+  siteConfig: SiteConfig;
+};
+
+export const ArchivePage = ({
+  archiveMonths,
+  siteConfig,
+}: ArchivePageProps) => (
+  <section class="page-section">
+    <div class="page-heading">
+      <p class="eyebrow">Archive</p>
+      <h1>All posts by month</h1>
+    </div>
+    <div class="archive-list">
+      {archiveMonths.map((archiveMonth) => (
+        <section class="archive-month" key={archiveMonth.month}>
+          <h2>{archiveMonth.label}</h2>
+          <ul>
+            {archiveMonth.posts.map((post) => (
+              <li key={post.id}>
+                <a href={postPath(siteConfig, post.slug)}>{post.title}</a>
+                <DateTime date={post.publishedAt} />
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  </section>
+);

--- a/src/presentation/pages/HomePage.tsx
+++ b/src/presentation/pages/HomePage.tsx
@@ -1,0 +1,19 @@
+import type { SiteConfig } from "../../config/site.config";
+import type { Post } from "../../content/domain/Post";
+import { PostList } from "../components/PostList";
+
+type HomePageProps = {
+  posts: Post[];
+  siteConfig: SiteConfig;
+};
+
+export const HomePage = ({ posts, siteConfig }: HomePageProps) => (
+  <section class="page-section">
+    <div class="page-heading">
+      <p class="eyebrow">GitHub Issues backed static blog</p>
+      <h1>{siteConfig.title}</h1>
+      <p>{siteConfig.description}</p>
+    </div>
+    <PostList posts={posts} siteConfig={siteConfig} />
+  </section>
+);

--- a/src/presentation/pages/NotFoundPage.tsx
+++ b/src/presentation/pages/NotFoundPage.tsx
@@ -1,0 +1,19 @@
+import type { SiteConfig } from "../../config/site.config";
+import { withBasePath } from "../../shared/path";
+
+type NotFoundPageProps = {
+  siteConfig: SiteConfig;
+};
+
+export const NotFoundPage = ({ siteConfig }: NotFoundPageProps) => (
+  <section class="page-section">
+    <div class="page-heading">
+      <p class="eyebrow">404</p>
+      <h1>Page not found</h1>
+      <p>The requested page is not available in the generated site.</p>
+      <a class="button-link" href={withBasePath(siteConfig, "/")}>
+        Go home
+      </a>
+    </div>
+  </section>
+);

--- a/src/presentation/pages/PostPage.tsx
+++ b/src/presentation/pages/PostPage.tsx
@@ -1,0 +1,31 @@
+import type { SiteConfig } from "../../config/site.config";
+import type { Post } from "../../content/domain/Post";
+import { DateTime } from "../components/DateTime";
+import { PostBody } from "../components/PostBody";
+import { TagBadge } from "../components/TagBadge";
+
+type PostPageProps = {
+  post: Post;
+  siteConfig: SiteConfig;
+};
+
+export const PostPage = ({ post, siteConfig }: PostPageProps) => (
+  <article class="post-page">
+    <header class="post-page__header">
+      <p class="post-card__meta">
+        <DateTime date={post.publishedAt} />
+        <span>{post.readingTimeMinutes} min read</span>
+      </p>
+      <h1>{post.title}</h1>
+      <p>{post.description}</p>
+      {post.tags.length > 0 ? (
+        <div class="tag-list">
+          {post.tags.map((tag) => (
+            <TagBadge key={tag} siteConfig={siteConfig} tag={tag} />
+          ))}
+        </div>
+      ) : null}
+    </header>
+    <PostBody post={post} />
+  </article>
+);

--- a/src/presentation/pages/TagPage.tsx
+++ b/src/presentation/pages/TagPage.tsx
@@ -1,0 +1,21 @@
+import type { SiteConfig } from "../../config/site.config";
+import type { TagGroup } from "../../content/usecases/buildContentIndex";
+import { PostList } from "../components/PostList";
+
+type TagPageProps = {
+  siteConfig: SiteConfig;
+  tag: TagGroup;
+};
+
+export const TagPage = ({ siteConfig, tag }: TagPageProps) => (
+  <section class="page-section">
+    <div class="page-heading">
+      <p class="eyebrow">Tag</p>
+      <h1>{tag.name}</h1>
+      <p>
+        {tag.posts.length} {tag.posts.length === 1 ? "post" : "posts"}
+      </p>
+    </div>
+    <PostList posts={tag.posts} siteConfig={siteConfig} />
+  </section>
+);

--- a/src/shared/date.ts
+++ b/src/shared/date.ts
@@ -1,0 +1,10 @@
+export const formatDate = (date: Date): string =>
+  new Intl.DateTimeFormat("en", {
+    day: "2-digit",
+    month: "short",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(date);
+
+export const formatMachineDate = (date: Date): string =>
+  date.toISOString().slice(0, 10);

--- a/src/shared/path.ts
+++ b/src/shared/path.ts
@@ -1,0 +1,24 @@
+import type { SiteConfig } from "../config/site.config";
+
+export const withBasePath = (
+  siteConfig: Pick<SiteConfig, "basePath">,
+  pathname: string,
+): string => {
+  const normalizedPath = pathname.startsWith("/") ? pathname : `/${pathname}`;
+
+  if (!siteConfig.basePath) {
+    return normalizedPath;
+  }
+
+  return `${siteConfig.basePath}${normalizedPath}`;
+};
+
+export const postPath = (
+  siteConfig: Pick<SiteConfig, "basePath">,
+  slug: string,
+): string => withBasePath(siteConfig, `/posts/${slug}/`);
+
+export const tagPath = (
+  siteConfig: Pick<SiteConfig, "basePath">,
+  tag: string,
+): string => withBasePath(siteConfig, `/tags/${encodeURIComponent(tag)}/`);

--- a/src/shared/sort.ts
+++ b/src/shared/sort.ts
@@ -1,0 +1,14 @@
+import type { Post } from "../content/domain/Post";
+
+export const comparePostsByPublishOrder = (a: Post, b: Post): number => {
+  if (a.pinned !== b.pinned) {
+    return a.pinned ? -1 : 1;
+  }
+
+  const publishedDiff = b.publishedAt.getTime() - a.publishedAt.getTime();
+  if (publishedDiff !== 0) {
+    return publishedDiff;
+  }
+
+  return a.slug.localeCompare(b.slug);
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,253 @@
+:root {
+  color-scheme: light dark;
+  --background: #f7f4ee;
+  --border: #d8d3c8;
+  --muted: #69655f;
+  --panel: #fffdf8;
+  --text: #1d1c1a;
+  --accent: #1f6f68;
+  --accent-strong: #0b4f49;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--text);
+  font-family:
+    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  line-height: 1.65;
+}
+
+a {
+  color: var(--accent-strong);
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.18em;
+}
+
+.site-header,
+.site-footer,
+.site-main {
+  width: min(100% - 32px, 880px);
+  margin-inline: auto;
+}
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding-block: 28px;
+}
+
+.site-header__brand {
+  color: var(--text);
+  font-size: 1.1rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.site-header__nav {
+  display: flex;
+  gap: 18px;
+  font-size: 0.95rem;
+}
+
+.site-main {
+  padding-block: 44px 64px;
+}
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.9rem;
+  padding-block: 28px;
+}
+
+.page-section,
+.post-page {
+  display: grid;
+  gap: 32px;
+}
+
+.page-heading {
+  display: grid;
+  gap: 10px;
+  max-width: 680px;
+}
+
+.page-heading h1,
+.post-page__header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 4rem);
+  line-height: 1.05;
+}
+
+.page-heading p,
+.post-page__header p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.eyebrow {
+  color: var(--accent-strong);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.post-list {
+  display: grid;
+  gap: 18px;
+}
+
+.post-card {
+  display: grid;
+  gap: 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+  padding: 22px;
+}
+
+.post-card__header {
+  display: grid;
+  gap: 6px;
+}
+
+.post-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.post-card__title {
+  margin: 0;
+  font-size: 1.35rem;
+  line-height: 1.25;
+}
+
+.post-card__title a {
+  color: var(--text);
+  text-decoration: none;
+}
+
+.post-card__excerpt {
+  margin: 0;
+  color: var(--muted);
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tag-badge {
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  border-radius: 999px;
+  color: var(--accent-strong);
+  font-size: 0.82rem;
+  line-height: 1;
+  padding: 7px 10px;
+  text-decoration: none;
+}
+
+.post-page__header {
+  display: grid;
+  gap: 14px;
+  max-width: 720px;
+}
+
+.post-body {
+  display: grid;
+  gap: 16px;
+  max-width: 720px;
+}
+
+.post-body p {
+  margin: 0;
+}
+
+.archive-list {
+  display: grid;
+  gap: 24px;
+}
+
+.archive-month {
+  display: grid;
+  gap: 8px;
+}
+
+.archive-month h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.archive-month ul {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+}
+
+.archive-month li {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 8px 18px;
+  border-bottom: 1px solid var(--border);
+  list-style: none;
+  padding-block: 8px;
+}
+
+.archive-month time {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.button-link {
+  display: inline-flex;
+  width: fit-content;
+  border-radius: 6px;
+  background: var(--accent-strong);
+  color: #fff;
+  font-weight: 700;
+  padding: 10px 14px;
+  text-decoration: none;
+}
+
+.empty-state {
+  color: var(--muted);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #151615;
+    --border: #393c37;
+    --muted: #b8b3aa;
+    --panel: #1e201d;
+    --text: #f1eee7;
+    --accent: #65bdb3;
+    --accent-strong: #8bd8cf;
+  }
+}
+
+@media (max-width: 640px) {
+  .site-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .site-main {
+    padding-block-start: 28px;
+  }
+}

--- a/tests/integration/build.test.ts
+++ b/tests/integration/build.test.ts
@@ -1,0 +1,33 @@
+import { access, rm } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildSite } from "../../src/build/build";
+
+const distDir = path.resolve("dist");
+
+const exists = async (filePath: string): Promise<boolean> => {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+describe("buildSite", () => {
+  it("generates static HTML and CSS files", async () => {
+    await rm(distDir, { recursive: true, force: true });
+
+    await buildSite();
+
+    expect(await exists(path.join(distDir, "index.html"))).toBe(true);
+    expect(await exists(path.join(distDir, "posts", "index.html"))).toBe(true);
+    expect(
+      await exists(path.join(distDir, "posts", "hello-hono", "index.html")),
+    ).toBe(true);
+    expect(await exists(path.join(distDir, "archive", "index.html"))).toBe(
+      true,
+    );
+    expect(await exists(path.join(distDir, "static", "styles.css"))).toBe(true);
+  });
+});

--- a/tests/unit/contentIndex.test.ts
+++ b/tests/unit/contentIndex.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import type { Post } from "../../src/content/domain/Post";
+import { buildContentIndex } from "../../src/content/usecases/buildContentIndex";
+import { getPostBySlug } from "../../src/content/usecases/getPostBySlug";
+import { listArchiveMonths } from "../../src/content/usecases/listArchiveMonths";
+import { listPublishedPosts } from "../../src/content/usecases/listPublishedPosts";
+import { listTags } from "../../src/content/usecases/listTags";
+
+const createPost = (overrides: Partial<Post> = {}): Post => ({
+  id: overrides.id ?? "post-1",
+  source: overrides.source ?? {
+    type: "github-issue",
+    issueNumber: 1,
+    issueUrl: "https://github.com/6uclz1/minimal-blog/issues/1",
+  },
+  slug: overrides.slug ?? "first-post",
+  title: overrides.title ?? "First Post",
+  description: overrides.description ?? "Description",
+  excerpt: overrides.excerpt ?? "Excerpt",
+  bodyMarkdown: overrides.bodyMarkdown ?? "Body",
+  bodyHtml: overrides.bodyHtml ?? "<p>Body</p>",
+  labels: overrides.labels ?? ["post", "published"],
+  tags: overrides.tags ?? [],
+  status: overrides.status ?? "published",
+  pinned: overrides.pinned ?? false,
+  hidden: overrides.hidden ?? false,
+  noindex: overrides.noindex ?? false,
+  canonicalUrl: overrides.canonicalUrl,
+  ogImage: overrides.ogImage,
+  publishedAt: overrides.publishedAt ?? new Date("2026-04-28T00:00:00.000Z"),
+  updatedAt: overrides.updatedAt ?? new Date("2026-04-28T00:00:00.000Z"),
+  author: overrides.author ?? "6uclz1",
+  readingTimeMinutes: overrides.readingTimeMinutes ?? 1,
+});
+
+describe("buildContentIndex", () => {
+  it("sorts visible published posts by pinned first, then publishedAt descending", () => {
+    const olderPinned = createPost({
+      id: "pinned",
+      slug: "pinned",
+      pinned: true,
+      publishedAt: new Date("2026-04-01T00:00:00.000Z"),
+    });
+    const newest = createPost({
+      id: "newest",
+      slug: "newest",
+      publishedAt: new Date("2026-04-30T00:00:00.000Z"),
+    });
+    const older = createPost({
+      id: "older",
+      slug: "older",
+      publishedAt: new Date("2026-04-20T00:00:00.000Z"),
+    });
+
+    const index = buildContentIndex([older, newest, olderPinned]);
+
+    expect(listPublishedPosts(index).map((post) => post.slug)).toEqual([
+      "pinned",
+      "newest",
+      "older",
+    ]);
+  });
+
+  it("keeps hidden posts retrievable by slug but excludes them from list pages", () => {
+    const visible = createPost({ id: "visible", slug: "visible" });
+    const hidden = createPost({ id: "hidden", slug: "hidden", hidden: true });
+
+    const index = buildContentIndex([hidden, visible]);
+
+    expect(getPostBySlug(index, "hidden")).toBe(hidden);
+    expect(listPublishedPosts(index).map((post) => post.slug)).toEqual([
+      "visible",
+    ]);
+  });
+
+  it("excludes draft and archived posts from public lists", () => {
+    const published = createPost({ id: "published", slug: "published" });
+    const draft = createPost({
+      id: "draft",
+      slug: "draft",
+      status: "draft",
+    });
+    const archived = createPost({
+      id: "archived",
+      slug: "archived",
+      status: "archived",
+    });
+
+    const index = buildContentIndex([draft, archived, published]);
+
+    expect(listPublishedPosts(index).map((post) => post.slug)).toEqual([
+      "published",
+    ]);
+  });
+
+  it("groups visible published posts by tag", () => {
+    const typescript = createPost({
+      id: "typescript",
+      slug: "typescript",
+      tags: ["typescript"],
+    });
+    const hidden = createPost({
+      id: "hidden",
+      slug: "hidden",
+      tags: ["typescript"],
+      hidden: true,
+    });
+    const architecture = createPost({
+      id: "architecture",
+      slug: "architecture",
+      tags: ["architecture"],
+    });
+
+    const index = buildContentIndex([hidden, architecture, typescript]);
+
+    expect(listTags(index).map((tag) => tag.name)).toEqual([
+      "architecture",
+      "typescript",
+    ]);
+    expect(
+      listTags(index).find((tag) => tag.name === "typescript")?.posts,
+    ).toEqual([typescript]);
+  });
+
+  it("groups visible published posts by archive month", () => {
+    const april = createPost({
+      id: "april",
+      slug: "april",
+      publishedAt: new Date("2026-04-30T00:00:00.000Z"),
+    });
+    const march = createPost({
+      id: "march",
+      slug: "march",
+      publishedAt: new Date("2026-03-15T00:00:00.000Z"),
+    });
+
+    const index = buildContentIndex([march, april]);
+
+    expect(listArchiveMonths(index).map((month) => month.month)).toEqual([
+      "2026-04",
+      "2026-03",
+    ]);
+  });
+
+  it("throws a clear error for duplicate slugs", () => {
+    const first = createPost({ id: "first", slug: "duplicate" });
+    const second = createPost({ id: "second", slug: "duplicate" });
+
+    expect(() => buildContentIndex([first, second])).toThrow(
+      'Duplicate post slug: "duplicate"',
+    );
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx",
+    "types": ["node", "vitest/globals"],
+    "noEmit": true
+  },
+  "include": ["src", "tests", "vitest.config.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## 概要

minimal-blog を v2 の土台として作り直す最初の PR です。GitHub Issues CMS 連携はまだ実装せず、fixture の Post から静的 HTML を生成できる skeleton だけを追加しています。

`dependencies` は runtime では `hono` のみにし、Tailwind CSS は使わず `src/styles.css` の手書き CSS を `dist/static/styles.css` にコピーする構成です。

## 変更内容

- TypeScript + Hono JSX + Hono SSG の最小プロジェクト構成を追加
- `Post` domain model、`ContentRepository` port、content index/usecase を追加
- fixture repository から `/`, `/posts/`, `/posts/:slug/`, `/tags/:tag/`, `/archive/` を静的生成
- handwritten CSS と build pipeline を追加
- content index の unit test と build integration test を追加
- future agent 向けの `AGENTS.md` を追加

## 構成

```mermaid
flowchart TD
  FixturePosts[Fixture Posts] --> Repository[FixtureContentRepository]
  Repository --> PostModel[Post Domain Model]
  PostModel --> ContentIndex[ContentIndex / Usecases]
  ContentIndex --> HonoApp[Hono Routes + JSX Pages]
  HonoApp --> SSG[Hono SSG]
  SSG --> Dist[dist static files]
  Styles[src/styles.css] --> StaticCss[dist/static/styles.css]
```

## 確認したこと

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm ls --omit=dev --depth=0` で runtime dependency が `hono` のみであること

## この PR でやらないこと

- GitHub Issues API adapter
- Markdown rendering / sanitization
- RSS / sitemap / search index
- GitHub Actions Pages deploy
