### PR TITLE
[codex] Add build-time social previews

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,9 @@ jobs:
           node-version: "22"
           cache: npm
 
+      - name: Install Japanese fonts
+        run: sudo apt-get update && sudo apt-get install -y fonts-noto-cjk
+
       - name: Install dependencies
         run: npm ci
 
@@ -63,6 +66,9 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
+      - name: Install Japanese fonts
+        run: sudo apt-get update && sudo apt-get install -y fonts-noto-cjk
 
       - name: Install dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -92,12 +92,28 @@ ogImage: /og/custom.png
 
 Fallbacks:
 
-- `slug`: generated from the issue title
+- `slug`: generated from ASCII URL text in the issue title, or `issue-<number>` when the title has no ASCII URL text
 - `description`: generated from the rendered excerpt
 - `publishedAt`: issue `created_at`
 - `updatedAt`: issue `updated_at`
 - `tags`: labels that start with `tag:`
-- `ogImage`: `siteConfig.defaultOgImage`
+- `ogImage`: optional; when omitted, an article-specific OGP PNG is generated at build time
+
+`ogImage` overrides the generated article image. Root-relative paths such as `/og/custom.png` are resolved against `siteConfig.url`, and fully qualified HTTPS URLs are preserved. Use 1200x630 images for custom social preview assets.
+
+## Social previews / OGP
+
+`npm run build` writes social preview metadata into the initial HTML head and generates PNG images under `dist/og/`.
+
+Article pages use an article-specific OGP PNG unless frontmatter provides `ogImage`. Home, posts, archive, and tag pages use the generated default site OGP image. Generated and custom image URLs are emitted as absolute URLs under `siteConfig.url`.
+
+To verify locally:
+
+```sh
+npm run build
+```
+
+Then inspect `dist/posts/<slug>/index.html` for `og:image` and `twitter:image`, and inspect generated images under `dist/og/`. After deployment, external social preview debuggers can be used against the GitHub Pages URL.
 
 ## Deployment
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.8",
+        "@resvg/resvg-js": "^2.6.2",
         "@types/node": "^24.10.1",
         "tsx": "^4.20.6",
         "typescript": "^5.9.3",
@@ -703,6 +704,246 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.8",
+    "@resvg/resvg-js": "^2.6.2",
     "@types/node": "^24.10.1",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",

--- a/src/app/routes/post.route.tsx
+++ b/src/app/routes/post.route.tsx
@@ -58,9 +58,9 @@ export const registerPostRoutes = (app: Hono, options: RouteOptions): void => {
           metadata={createMetadata(options.siteConfig, {
             canonicalUrl: post.canonicalUrl,
             description: post.description,
-            image: post.ogImage,
             noindex: post.noindex,
             path: `/posts/${post.slug}/`,
+            post,
             title: post.title,
             type: "article",
           })}

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -6,6 +6,7 @@ import {
   type CreateBuildContextOptions,
   createBuildContext,
 } from "./createBuildContext";
+import { generateOgImages } from "./generateOgImages";
 import { generateStaticSite } from "./generateStaticSite";
 import { validateOutput } from "./validateOutput";
 
@@ -18,7 +19,8 @@ export const buildSite = async (
   await cleanDist(distDir);
   await generateStaticSite(context.app, distDir);
   await copyPublicAssets(distDir);
-  await validateOutput(distDir, context.contentIndex);
+  await generateOgImages(distDir, context.siteConfig, context.contentIndex);
+  await validateOutput(distDir, context.siteConfig, context.contentIndex);
 };
 
 const isMainModule = (): boolean => {

--- a/src/build/createBuildContext.ts
+++ b/src/build/createBuildContext.ts
@@ -46,6 +46,5 @@ const createContentRepository = (
 
   return new GitHubIssuesContentRepository({
     client,
-    defaultOgImage: siteConfig.defaultOgImage,
   });
 };

--- a/src/build/generateOgImages.ts
+++ b/src/build/generateOgImages.ts
@@ -1,0 +1,36 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { SiteConfig } from "../config/site.config";
+import type { ContentIndex } from "../content/usecases/buildContentIndex";
+import {
+  createDefaultOgImageDescriptor,
+  createPostOgImageDescriptor,
+  publicOgImagePathToDistPath,
+} from "../seo/ogImage/paths";
+import { renderOgImagePng } from "../seo/ogImage/renderPng";
+import { createOgImageSvg } from "../seo/ogImage/svg";
+
+export const generateOgImages = async (
+  distDir: string,
+  siteConfig: SiteConfig,
+  contentIndex: ContentIndex,
+): Promise<void> => {
+  const descriptors = [
+    createDefaultOgImageDescriptor(siteConfig),
+    ...contentIndex.detailPosts
+      .filter((post) => !post.ogImage)
+      .map((post) => createPostOgImageDescriptor(siteConfig, post)),
+  ];
+
+  for (const descriptor of descriptors) {
+    const filePath = publicOgImagePathToDistPath(
+      distDir,
+      descriptor.publicPath,
+    );
+    const svg = createOgImageSvg(descriptor);
+    const png = renderOgImagePng(svg);
+
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, png);
+  }
+};

--- a/src/build/validateOutput.ts
+++ b/src/build/validateOutput.ts
@@ -1,9 +1,16 @@
-import { access } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import path from "node:path";
+import type { SiteConfig } from "../config/site.config";
 import type { ContentIndex } from "../content/usecases/buildContentIndex";
+import {
+  createDefaultOgImageDescriptor,
+  createPostOgImageDescriptor,
+  publicOgImagePathToDistPath,
+} from "../seo/ogImage/paths";
 
 export const validateOutput = async (
   distDir: string,
+  siteConfig: SiteConfig,
   contentIndex: ContentIndex,
 ): Promise<void> => {
   const requiredFiles = [
@@ -22,6 +29,21 @@ export const validateOutput = async (
   for (const requiredFile of requiredFiles) {
     await assertFileExists(path.join(distDir, requiredFile));
   }
+
+  const requiredOgImages = [
+    createDefaultOgImageDescriptor(siteConfig),
+    ...contentIndex.detailPosts
+      .filter((post) => !post.ogImage)
+      .map((post) => createPostOgImageDescriptor(siteConfig, post)),
+  ];
+
+  for (const descriptor of requiredOgImages) {
+    await assertPngSize(
+      publicOgImagePathToDistPath(distDir, descriptor.publicPath),
+      descriptor.width,
+      descriptor.height,
+    );
+  }
 };
 
 const assertFileExists = async (filePath: string): Promise<void> => {
@@ -29,5 +51,26 @@ const assertFileExists = async (filePath: string): Promise<void> => {
     await access(filePath);
   } catch {
     throw new Error(`Expected generated file is missing: ${filePath}`);
+  }
+};
+
+const assertPngSize = async (
+  filePath: string,
+  expectedWidth: number,
+  expectedHeight: number,
+): Promise<void> => {
+  const png = await readFile(filePath);
+  const signature = png.subarray(0, 8).toString("hex");
+  const width = png.readUInt32BE(16);
+  const height = png.readUInt32BE(20);
+
+  if (signature !== "89504e470d0a1a0a") {
+    throw new Error(`Expected generated OGP image to be a PNG: ${filePath}`);
+  }
+
+  if (width !== expectedWidth || height !== expectedHeight) {
+    throw new Error(
+      `Expected generated OGP image to be ${expectedWidth}x${expectedHeight}: ${filePath}`,
+    );
   }
 };

--- a/src/cms/github-issues/GitHubIssuesContentRepository.ts
+++ b/src/cms/github-issues/GitHubIssuesContentRepository.ts
@@ -6,25 +6,20 @@ import { issueToPost } from "./issueToPost";
 
 type GitHubIssuesContentRepositoryOptions = {
   client: Pick<GitHubIssueClient, "listIssues">;
-  defaultOgImage?: string;
 };
 
 export class GitHubIssuesContentRepository implements ContentRepository {
   private readonly client: Pick<GitHubIssueClient, "listIssues">;
-  private readonly defaultOgImage?: string;
 
   constructor(options: GitHubIssuesContentRepositoryOptions) {
     this.client = options.client;
-    this.defaultOgImage = options.defaultOgImage;
   }
 
   async listPosts(): Promise<Post[]> {
     const issues = await this.client.listIssues();
-    const posts = issues.filter(isPublicPostIssue).map((issue) =>
-      issueToPost(issue, {
-        defaultOgImage: this.defaultOgImage,
-      }),
-    );
+    const posts = issues
+      .filter(isPublicPostIssue)
+      .map((issue) => issueToPost(issue));
 
     return resolveDuplicateSlugs(posts);
   }

--- a/src/cms/github-issues/issueToPost.ts
+++ b/src/cms/github-issues/issueToPost.ts
@@ -11,14 +11,7 @@ import {
 } from "./labels";
 import { parseIssueFrontmatter } from "./parseIssueFrontmatter";
 
-type IssueToPostOptions = {
-  defaultOgImage?: string;
-};
-
-export const issueToPost = (
-  issue: GitHubIssue,
-  options: IssueToPostOptions = {},
-): Post => {
+export const issueToPost = (issue: GitHubIssue): Post => {
   const parsedBody = parseIssueFrontmatter(issue.body ?? "");
   const bodyHtml = renderMarkdown(parsedBody.bodyMarkdown);
   const excerpt = extractExcerpt(bodyHtml);
@@ -44,7 +37,7 @@ export const issueToPost = (
     hidden: hasLabel(issue, supportedLabels.hidden),
     noindex: hasLabel(issue, supportedLabels.noindex),
     canonicalUrl: parsedBody.frontmatter.canonicalUrl,
-    ogImage: parsedBody.frontmatter.ogImage ?? options.defaultOgImage,
+    ogImage: parsedBody.frontmatter.ogImage,
     publishedAt: parseDate(
       parsedBody.frontmatter.publishedAt ?? issue.created_at,
       "publishedAt",
@@ -56,9 +49,9 @@ export const issueToPost = (
 };
 
 export const createSlug = (value: string, issueNumber?: number): string => {
-  const slug = Array.from(value.trim().toLowerCase())
+  const slug = Array.from(value.trim().toLowerCase().normalize("NFKD"))
     .map((character) => {
-      if (/[\p{Letter}\p{Number}]/u.test(character)) {
+      if (/[a-z0-9]/.test(character)) {
         return character;
       }
 

--- a/src/content/fixtures/fixturePosts.ts
+++ b/src/content/fixtures/fixturePosts.ts
@@ -48,6 +48,7 @@ export const fixturePosts: Post[] = [
     pinned: false,
     hidden: false,
     noindex: false,
+    ogImage: "/og/custom-fixture.png",
     publishedAt: new Date("2026-04-29T00:00:00.000Z"),
     updatedAt: new Date("2026-04-29T00:00:00.000Z"),
     author: "6uclz1",

--- a/src/presentation/components/Layout.tsx
+++ b/src/presentation/components/Layout.tsx
@@ -666,7 +666,22 @@ export const Layout = ({
           <meta property="og:type" content={openGraph.type} />
           <meta property="og:url" content={openGraph.url} />
           <meta property="og:image" content={openGraph.image} />
+          <meta
+            property="og:image:width"
+            content={String(openGraph.imageWidth)}
+          />
+          <meta
+            property="og:image:height"
+            content={String(openGraph.imageHeight)}
+          />
+          <meta property="og:image:alt" content={openGraph.imageAlt} />
+          <meta property="og:site_name" content={openGraph.siteName} />
+          <meta property="og:locale" content={openGraph.locale} />
           <meta name="twitter:card" content="summary_large_image" />
+          <meta name="twitter:title" content={openGraph.title} />
+          <meta name="twitter:description" content={openGraph.description} />
+          <meta name="twitter:image" content={openGraph.image} />
+          <meta name="twitter:image:alt" content={openGraph.imageAlt} />
           <script>{raw(themeScript)}</script>
           <link
             rel="stylesheet"

--- a/src/seo/metadata.ts
+++ b/src/seo/metadata.ts
@@ -1,12 +1,21 @@
 import type { SiteConfig } from "../config/site.config";
+import type { Post } from "../content/domain/Post";
+import {
+  ogImageHeight,
+  ogImageWidth,
+  resolvePageOgImagePath,
+} from "./ogImage/paths";
 import { absoluteUrl } from "./url";
 
 export type PageMetadataInput = {
   canonicalUrl?: string;
   description?: string;
   image?: string;
+  imageAlt?: string;
+  locale?: string;
   noindex?: boolean;
   path: string;
+  post?: Post;
   title?: string;
   type?: "article" | "website";
 };
@@ -15,9 +24,15 @@ export type PageMetadata = {
   canonicalUrl: string;
   description: string;
   image: string;
+  imageAlt: string;
+  imageHeight: number;
+  imageWidth: number;
+  locale: string;
   noindex: boolean;
+  siteName: string;
   title: string;
   type: "article" | "website";
+  url: string;
 };
 
 export const createMetadata = (
@@ -27,13 +42,23 @@ export const createMetadata = (
   const pageTitle = input.title
     ? `${input.title} | ${siteConfig.title}`
     : siteConfig.title;
+  const url = absoluteUrl(siteConfig, input.path);
 
   return {
-    canonicalUrl: input.canonicalUrl ?? absoluteUrl(siteConfig, input.path),
+    canonicalUrl: input.canonicalUrl ?? url,
     description: input.description ?? siteConfig.description,
-    image: input.image ?? siteConfig.defaultOgImage,
+    image: resolvePageOgImagePath(siteConfig, {
+      image: input.image,
+      post: input.post,
+    }),
+    imageAlt: input.imageAlt ?? pageTitle,
+    imageHeight: ogImageHeight,
+    imageWidth: ogImageWidth,
+    locale: input.locale ?? "ja_JP",
     noindex: input.noindex ?? false,
+    siteName: siteConfig.title,
     title: pageTitle,
     type: input.type ?? "website",
+    url,
   };
 };

--- a/src/seo/ogImage/paths.ts
+++ b/src/seo/ogImage/paths.ts
@@ -1,0 +1,96 @@
+import crypto from "node:crypto";
+import path from "node:path";
+import type { SiteConfig } from "../../config/site.config";
+import type { Post } from "../../content/domain/Post";
+
+export const ogImageWidth = 1200;
+export const ogImageHeight = 630;
+
+export type OgImageDescriptor = {
+  alt: string;
+  description: string;
+  height: number;
+  publicPath: string;
+  siteTitle: string;
+  title: string;
+  width: number;
+};
+
+export const createDefaultOgImageDescriptor = (
+  siteConfig: SiteConfig,
+): OgImageDescriptor => {
+  const title = siteConfig.title;
+  const hash = shortHash(
+    [
+      "default",
+      siteConfig.title,
+      siteConfig.description,
+      siteConfig.defaultOgImage,
+    ].join("\n"),
+  );
+
+  return {
+    alt: title,
+    description: siteConfig.description,
+    height: ogImageHeight,
+    publicPath: `/og/default-${hash}.png`,
+    siteTitle: siteConfig.title,
+    title,
+    width: ogImageWidth,
+  };
+};
+
+export const createPostOgImageDescriptor = (
+  siteConfig: SiteConfig,
+  post: Post,
+): OgImageDescriptor => {
+  const hash = shortHash(
+    [
+      "post",
+      post.id,
+      post.slug,
+      post.title,
+      post.description,
+      post.publishedAt.toISOString(),
+      post.tags.join(","),
+      siteConfig.title,
+    ].join("\n"),
+  );
+
+  return {
+    alt: `${post.title} | ${siteConfig.title}`,
+    description: post.description || post.excerpt || siteConfig.description,
+    height: ogImageHeight,
+    publicPath: `/og/posts/${post.slug}-${hash}.png`,
+    siteTitle: siteConfig.title,
+    title: post.title,
+    width: ogImageWidth,
+  };
+};
+
+export const resolvePageOgImagePath = (
+  siteConfig: SiteConfig,
+  options: { image?: string; post?: Post } = {},
+): string => {
+  if (options.image) {
+    return options.image;
+  }
+
+  if (options.post?.ogImage) {
+    return options.post.ogImage;
+  }
+
+  if (options.post) {
+    return createPostOgImageDescriptor(siteConfig, options.post).publicPath;
+  }
+
+  return createDefaultOgImageDescriptor(siteConfig).publicPath;
+};
+
+export const publicOgImagePathToDistPath = (
+  distDir: string,
+  publicPath: string,
+): string => path.join(distDir, publicPath.replace(/^\/+/, ""));
+
+const shortHash = (value: string): string =>
+  crypto.createHash("sha256").update(value).digest("hex").slice(0, 10);

--- a/src/seo/ogImage/renderPng.ts
+++ b/src/seo/ogImage/renderPng.ts
@@ -1,0 +1,12 @@
+import { Resvg } from "@resvg/resvg-js";
+
+export const renderOgImagePng = (svg: string): Buffer => {
+  const renderer = new Resvg(svg, {
+    fitTo: {
+      mode: "width",
+      value: 1200,
+    },
+  });
+
+  return renderer.render().asPng();
+};

--- a/src/seo/ogImage/svg.ts
+++ b/src/seo/ogImage/svg.ts
@@ -1,0 +1,86 @@
+import type { OgImageDescriptor } from "./paths";
+import { ogImageHeight, ogImageWidth } from "./paths";
+
+const titleLineLength = 22;
+const descriptionLineLength = 42;
+
+export const createOgImageSvg = (descriptor: OgImageDescriptor): string => {
+  const titleLines = wrapText(descriptor.title, titleLineLength, 3);
+  const descriptionLines = wrapText(
+    descriptor.description,
+    descriptionLineLength,
+    2,
+  );
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${ogImageWidth}" height="${ogImageHeight}" viewBox="0 0 ${ogImageWidth} ${ogImageHeight}">
+  <rect width="1200" height="630" fill="#f4f4f1"/>
+  <rect x="56" y="56" width="1088" height="518" rx="0" fill="#09090b"/>
+  <path d="M56 438 C214 350 336 532 498 454 C654 379 734 216 895 278 C1014 324 1069 245 1144 188 L1144 574 L56 574 Z" fill="#d8ff6f" opacity="0.95"/>
+  <path d="M56 504 C236 423 355 609 548 526 C720 452 804 322 968 358 C1056 377 1105 336 1144 304 L1144 574 L56 574 Z" fill="#ff5a3d" opacity="0.78"/>
+  <text x="104" y="132" fill="#f4f4f1" font-family="Noto Sans CJK JP, Noto Sans JP, system-ui, sans-serif" font-size="30" font-weight="600">${escapeSvgText(descriptor.siteTitle)}</text>
+  <text x="104" y="264" fill="#f4f4f1" font-family="Noto Sans CJK JP, Noto Sans JP, system-ui, sans-serif" font-size="70" font-weight="700">
+${titleLines
+  .map(
+    (line, index) =>
+      `    <tspan x="104" dy="${index === 0 ? 0 : 82}">${escapeSvgText(line)}</tspan>`,
+  )
+  .join("\n")}
+  </text>
+  <text x="104" y="486" fill="#09090b" font-family="Noto Sans CJK JP, Noto Sans JP, system-ui, sans-serif" font-size="34" font-weight="600">
+${descriptionLines
+  .map(
+    (line, index) =>
+      `    <tspan x="104" dy="${index === 0 ? 0 : 44}">${escapeSvgText(line)}</tspan>`,
+  )
+  .join("\n")}
+  </text>
+</svg>`;
+};
+
+const wrapText = (value: string, maxLineLength: number, maxLines: number) => {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  const tokens = normalized.includes(" ")
+    ? normalized.split(" ")
+    : Array.from(normalized);
+  const lines: string[] = [];
+  let currentLine = "";
+
+  for (const token of tokens) {
+    const separator = normalized.includes(" ") && currentLine ? " " : "";
+    const nextLine = `${currentLine}${separator}${token}`;
+
+    if (nextLine.length > maxLineLength && currentLine) {
+      lines.push(currentLine);
+      currentLine = token;
+    } else {
+      currentLine = nextLine;
+    }
+
+    if (lines.length === maxLines) {
+      break;
+    }
+  }
+
+  if (currentLine && lines.length < maxLines) {
+    lines.push(currentLine);
+  }
+
+  if (lines.length === 0) {
+    return [""];
+  }
+
+  const usedText = lines.join(normalized.includes(" ") ? " " : "");
+  if (usedText.length < normalized.length) {
+    const lastLine = lines.at(-1) ?? "";
+    lines[lines.length - 1] = `${lastLine.replace(/.{1,3}$/, "")}...`;
+  }
+
+  return lines;
+};
+
+const escapeSvgText = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");

--- a/src/seo/openGraph.ts
+++ b/src/seo/openGraph.ts
@@ -5,6 +5,11 @@ import { absoluteAssetUrl } from "./url";
 export type OpenGraphMetadata = {
   description: string;
   image: string;
+  imageAlt: string;
+  imageHeight: number;
+  imageWidth: number;
+  locale: string;
+  siteName: string;
   title: string;
   type: "article" | "website";
   url: string;
@@ -16,7 +21,12 @@ export const createOpenGraphMetadata = (
 ): OpenGraphMetadata => ({
   description: metadata.description,
   image: absoluteAssetUrl(siteConfig, metadata.image),
+  imageAlt: metadata.imageAlt,
+  imageHeight: metadata.imageHeight,
+  imageWidth: metadata.imageWidth,
+  locale: metadata.locale,
+  siteName: metadata.siteName,
   title: metadata.title,
   type: metadata.type,
-  url: metadata.canonicalUrl,
+  url: metadata.url,
 });

--- a/src/seo/structuredData.ts
+++ b/src/seo/structuredData.ts
@@ -1,5 +1,6 @@
 import type { SiteConfig } from "../config/site.config";
 import type { Post } from "../content/domain/Post";
+import { resolvePageOgImagePath } from "./ogImage/paths";
 import { absoluteAssetUrl, absoluteUrl } from "./url";
 
 export type ArticleStructuredData = {
@@ -33,7 +34,7 @@ export const createArticleStructuredData = (
   headline: post.title,
   image: absoluteAssetUrl(
     siteConfig,
-    post.ogImage ?? siteConfig.defaultOgImage,
+    resolvePageOgImagePath(siteConfig, { post }),
   ),
   mainEntityOfPage: absoluteUrl(siteConfig, `/posts/${post.slug}/`),
 });

--- a/src/seo/url.ts
+++ b/src/seo/url.ts
@@ -4,6 +4,10 @@ export const absoluteUrl = (
   siteConfig: Pick<SiteConfig, "url">,
   path: string,
 ): string => {
+  if (/^https?:\/\//.test(path)) {
+    return path;
+  }
+
   const baseUrl = siteConfig.url.endsWith("/")
     ? siteConfig.url
     : `${siteConfig.url}/`;

--- a/tests/integration/GitHubIssuesContentRepository.test.ts
+++ b/tests/integration/GitHubIssuesContentRepository.test.ts
@@ -24,7 +24,6 @@ describe("GitHubIssuesContentRepository", () => {
     } satisfies Pick<GitHubIssueClient, "listIssues">;
     const repository = new GitHubIssuesContentRepository({
       client,
-      defaultOgImage: "/og-default.png",
     });
 
     const posts = await repository.listPosts();

--- a/tests/integration/build.test.ts
+++ b/tests/integration/build.test.ts
@@ -14,6 +14,17 @@ const exists = async (filePath: string): Promise<boolean> => {
   }
 };
 
+const readPngSize = async (
+  filePath: string,
+): Promise<{ height: number; width: number }> => {
+  const png = await readFile(filePath);
+
+  return {
+    height: png.readUInt32BE(20),
+    width: png.readUInt32BE(16),
+  };
+};
+
 describe("buildSite", () => {
   it("generates static files with the shared ambient design shell", async () => {
     await rm(distDir, { recursive: true, force: true });
@@ -33,11 +44,66 @@ describe("buildSite", () => {
     expect(await exists(path.join(distDir, "search-index.json"))).toBe(true);
     expect(await exists(path.join(distDir, "static", "styles.css"))).toBe(true);
 
-    const [homeHtml, postHtml, styles] = await Promise.all([
+    const [homeHtml, postHtml, styles, customOgHtml] = await Promise.all([
       readFile(path.join(distDir, "index.html"), "utf8"),
       readFile(path.join(distDir, "posts", "hello-hono", "index.html"), "utf8"),
       readFile(path.join(distDir, "static", "styles.css"), "utf8"),
+      readFile(
+        path.join(distDir, "posts", "content-model-first", "index.html"),
+        "utf8",
+      ),
     ]);
+
+    const generatedOgImageMatches = [
+      ...postHtml.matchAll(
+        /https:\/\/6uclz1\.github\.io\/minimal-blog\/(og\/posts\/hello-hono-[a-f0-9]{10}\.png)/g,
+      ),
+    ];
+    const defaultOgImageMatches = [
+      ...homeHtml.matchAll(
+        /https:\/\/6uclz1\.github\.io\/minimal-blog\/(og\/default-[a-f0-9]{10}\.png)/g,
+      ),
+    ];
+
+    expect(defaultOgImageMatches.length).toBeGreaterThanOrEqual(2);
+    expect(generatedOgImageMatches.length).toBeGreaterThanOrEqual(2);
+    expect(
+      await exists(path.join(distDir, defaultOgImageMatches[0]?.[1] ?? "")),
+    ).toBe(true);
+    expect(
+      await exists(path.join(distDir, generatedOgImageMatches[0]?.[1] ?? "")),
+    ).toBe(true);
+    expect(await exists(path.join(distDir, "og", "custom-fixture.png"))).toBe(
+      false,
+    );
+    await expect(
+      readPngSize(path.join(distDir, generatedOgImageMatches[0]?.[1] ?? "")),
+    ).resolves.toEqual({ height: 630, width: 1200 });
+
+    expect(postHtml).toContain('<meta property="og:title"');
+    expect(postHtml).toContain('<meta property="og:description"');
+    expect(postHtml).toContain('<meta property="og:type" content="article"');
+    expect(postHtml).toContain(
+      '<meta property="og:url" content="https://6uclz1.github.io/minimal-blog/posts/hello-hono/"',
+    );
+    expect(postHtml).toContain('<meta property="og:image"');
+    expect(postHtml).toContain(
+      '<meta property="og:image:width" content="1200"',
+    );
+    expect(postHtml).toContain(
+      '<meta property="og:image:height" content="630"',
+    );
+    expect(postHtml).toContain('<meta property="og:image:alt"');
+    expect(postHtml).toContain(
+      '<meta name="twitter:card" content="summary_large_image"',
+    );
+    expect(postHtml).toContain('<meta name="twitter:title"');
+    expect(postHtml).toContain('<meta name="twitter:description"');
+    expect(postHtml).toContain('<meta name="twitter:image"');
+    expect(homeHtml).not.toContain(["example", ".com"].join(""));
+    expect(postHtml).not.toContain(["example", ".com"].join(""));
+    expect(homeHtml).not.toContain("placehold.co");
+    expect(postHtml).not.toContain("placehold.co");
 
     expect(homeHtml).toContain('class="noise-field"');
     expect(homeHtml).toContain('data-ambient-field="true"');
@@ -67,6 +133,9 @@ describe("buildSite", () => {
     expect(postHtml).not.toContain("Next");
     expect(postHtml).not.toContain('class="post-nav__links"');
     expect(postHtml).not.toContain('class="post-nav__label"');
+    expect(customOgHtml).toContain(
+      'content="https://6uclz1.github.io/minimal-blog/og/custom-fixture.png"',
+    );
 
     expect(styles).toContain("--text-weight: 300");
     expect(styles).not.toContain("font-weight: 100");

--- a/tests/integration/documentation.test.ts
+++ b/tests/integration/documentation.test.ts
@@ -18,6 +18,8 @@ describe("project documentation", () => {
     expect(readme).toContain("Zero runtime dependencies except Hono");
     expect(readme).toContain("npm run build");
     expect(readme).toContain("tag:typescript");
+    expect(readme).toContain("Social previews / OGP");
+    expect(readme).toContain("article-specific OGP PNG");
 
     expect(agentInstructions).toContain("Do not introduce Next.js");
     expect(agentInstructions).toContain("Do not introduce a database");

--- a/tests/integration/publishWorkflow.test.ts
+++ b/tests/integration/publishWorkflow.test.ts
@@ -24,6 +24,7 @@ describe("publish workflow", () => {
     expect(workflow).toContain("npm run build");
     expect(workflow).toContain("actions/upload-pages-artifact@v3");
     expect(workflow).toContain("actions/deploy-pages@v4");
+    expect(workflow).toContain("fonts-noto-cjk");
     expect(workflow).toContain(
       ["GITHUB_TOKEN: $", "{{ secrets.GITHUB_TOKEN }}"].join(""),
     );

--- a/tests/unit/issueToPost.test.ts
+++ b/tests/unit/issueToPost.test.ts
@@ -4,9 +4,7 @@ import { loadIssueFixture } from "./githubIssueTestUtils";
 
 describe("issueToPost", () => {
   it("converts a published GitHub Issue into a normalized Post", async () => {
-    const post = issueToPost(await loadIssueFixture("published"), {
-      defaultOgImage: "/og-default.png",
-    });
+    const post = issueToPost(await loadIssueFixture("published"));
 
     expect(post).toMatchObject({
       id: "github-issue-10",
@@ -52,7 +50,7 @@ describe("issueToPost", () => {
       title: "Fallback Title",
     };
 
-    const post = issueToPost(issue, { defaultOgImage: "/og-default.png" });
+    const post = issueToPost(issue);
 
     expect(post.slug).toBe("fallback-title");
     expect(post.description).toBe(
@@ -60,7 +58,21 @@ describe("issueToPost", () => {
     );
     expect(post.publishedAt.toISOString()).toBe("2026-04-29T10:00:00.000Z");
     expect(post.hidden).toBe(true);
-    expect(post.ogImage).toBe("/og-default.png");
+    expect(post.ogImage).toBeUndefined();
+  });
+
+  it("falls back to an issue id slug when the title has no ASCII URL text", async () => {
+    const issue = {
+      ...(await loadIssueFixture("published")),
+      body: "本文です。",
+      number: 42,
+      title: "日本語の記事タイトル",
+    };
+
+    const post = issueToPost(issue);
+
+    expect(post.slug).toBe("issue-42");
+    expect(post.slug).not.toContain("日本語");
   });
 
   it("throws a clear error for malformed frontmatter", async () => {

--- a/tests/unit/seoGenerators.test.ts
+++ b/tests/unit/seoGenerators.test.ts
@@ -3,6 +3,11 @@ import type { SiteConfig } from "../../src/config/site.config";
 import type { Post } from "../../src/content/domain/Post";
 import { buildContentIndex } from "../../src/content/usecases/buildContentIndex";
 import { createMetadata } from "../../src/seo/metadata";
+import {
+  createDefaultOgImageDescriptor,
+  createPostOgImageDescriptor,
+  resolvePageOgImagePath,
+} from "../../src/seo/ogImage/paths";
 import { createOpenGraphMetadata } from "../../src/seo/openGraph";
 import { generateRssFeed } from "../../src/seo/rss";
 import { createSearchIndex } from "../../src/seo/searchIndex";
@@ -59,11 +64,78 @@ describe("SEO generators", () => {
       title: "First Post | Minimal Blog",
     });
     expect(openGraph).toMatchObject({
-      image: "https://6uclz1.github.io/minimal-blog/og-default.png",
+      imageAlt: "First Post | Minimal Blog",
+      imageHeight: 630,
+      imageWidth: 1200,
+      siteName: "Minimal Blog",
       title: "First Post | Minimal Blog",
       type: "website",
       url: "https://6uclz1.github.io/minimal-blog/posts/first-post/",
     });
+    expect(openGraph.image).toMatch(
+      /^https:\/\/6uclz1\.github\.io\/minimal-blog\/og\/default-[a-f0-9]{10}\.png$/,
+    );
+  });
+
+  it("resolves generated and custom Open Graph image paths centrally", () => {
+    const post = createPost({
+      slug: "generated-post",
+      title: "Generated Post",
+      description: "Generated social image text",
+    });
+    const descriptor = createPostOgImageDescriptor(siteConfig, post);
+
+    expect(descriptor.publicPath).toMatch(
+      /^\/og\/posts\/generated-post-[a-f0-9]{10}\.png$/,
+    );
+    expect(descriptor.width).toBe(1200);
+    expect(descriptor.height).toBe(630);
+    expect(resolvePageOgImagePath(siteConfig, { post })).toBe(
+      descriptor.publicPath,
+    );
+    expect(
+      resolvePageOgImagePath(siteConfig, {
+        post: createPost({ ogImage: "/og/custom.png" }),
+      }),
+    ).toBe("/og/custom.png");
+    expect(resolvePageOgImagePath(siteConfig)).toMatch(
+      /^\/og\/default-[a-f0-9]{10}\.png$/,
+    );
+  });
+
+  it("uses generated article image metadata when a post has no custom ogImage", () => {
+    const post = createPost({
+      slug: "article-with-generated-image",
+      title: "Article With Generated Image",
+    });
+    const metadata = createMetadata(siteConfig, {
+      description: post.description,
+      path: `/posts/${post.slug}/`,
+      post,
+      title: post.title,
+      type: "article",
+    });
+    const openGraph = createOpenGraphMetadata(siteConfig, metadata);
+
+    expect(openGraph).toMatchObject({
+      imageAlt: "Article With Generated Image | Minimal Blog",
+      imageHeight: 630,
+      imageWidth: 1200,
+      type: "article",
+    });
+    expect(openGraph.image).toMatch(
+      /^https:\/\/6uclz1\.github\.io\/minimal-blog\/og\/posts\/article-with-generated-image-[a-f0-9]{10}\.png$/,
+    );
+  });
+
+  it("creates deterministic default Open Graph image descriptors", () => {
+    const firstDescriptor = createDefaultOgImageDescriptor(siteConfig);
+    const secondDescriptor = createDefaultOgImageDescriptor(siteConfig);
+
+    expect(firstDescriptor).toEqual(secondDescriptor);
+    expect(firstDescriptor.publicPath).toMatch(
+      /^\/og\/default-[a-f0-9]{10}\.png$/,
+    );
   });
 
   it("generates an RSS feed with absolute post URLs and escaped XML", () => {


### PR DESCRIPTION
## 概要

GitHub Issues を CMS とする静的ブログに、build 時生成の OGP / Twitter Card 対応を追加しました。記事ページは frontmatter の `ogImage` があればそれを優先し、未指定の場合は 1200x630 の記事別 PNG を `dist/og/posts/` に生成します。トップ、一覧、アーカイブ、タグページは生成された default OGP 画像を使います。

URL 仕様も見直し、日本語タイトルだけの記事では URL slug に日本語を残さず `issue-<number>` に fallback するようにしました。

```mermaid
flowchart LR
  A["GitHub Issues"] --> B["CMS adapter"]
  B --> C["Post domain model"]
  C --> D["SEO metadata"]
  D --> E["Hono SSG HTML head"]
  C --> F["Build OGP image generator"]
  F --> G["dist/og/*.png"]
```

## 変更内容

- `PageMetadata` / OGP metadata に `og:image` の alt、width、height、site name、locale、Twitter Card fields を追加
- `src/seo/ogImage/` に deterministic な OGP path / SVG / PNG render helper を追加
- `src/build/generateOgImages.ts` を追加し、`npm run build` で default / article OGP PNG を生成
- `Post.ogImage` を frontmatter の明示指定として扱い、fallback 画像の決定を SEO/build 側へ移動
- GitHub Issue title 由来 slug を ASCII URL text に限定し、ASCII 化できない場合は `issue-<number>` に fallback
- GitHub Actions に `fonts-noto-cjk` を追加し、日本語 OGP 画像生成に対応
- README に frontmatter `ogImage` と Social previews / OGP の検証手順を追記

## 検証

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

## 影響

- runtime dependencies は引き続き `hono` のみです。
- PNG 生成の build-time dev dependency として `@resvg/resvg-js` を追加しています。
- custom `ogImage` は生成対象にせず、そのまま絶対 URL 化して HTML head に出力します。
